### PR TITLE
fix(animate): require --effect-type argument (closes #41)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,7 @@ enum Commands {
     /// Run animation effects
     Animate {
         /// Animation type: progress, typewriter, counter, chart-build, bars
-        #[arg(short = 't', long, default_value = "progress")]
+        #[arg(short = 't', long)]
         effect_type: String,
         /// Text content (for typewriter)
         #[arg(long)]


### PR DESCRIPTION
Fixes #41. This PR removes the default value from the animate command's --effect-type argument, making it a required field.