### PR TITLE
feat: implement watch command for live monitoring

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -13,3 +13,4 @@ pub mod gauge;
 pub mod heatmap;
 pub mod dashboard;
 pub mod layout;
+pub mod watch;

--- a/src/output/watch.rs
+++ b/src/output/watch.rs
@@ -1,0 +1,251 @@
+use crossterm::{cursor, terminal, ExecutableCommand};
+use std::io::{self, Write};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Parse interval string like "1s", "500ms", "2.5s" into Duration
+pub fn parse_interval(interval: &str) -> Result<Duration, String> {
+    let interval = interval.trim();
+
+    if interval.ends_with("ms") {
+        let ms = interval
+            .trim_end_matches("ms")
+            .parse::<u64>()
+            .map_err(|_| format!("Invalid milliseconds: {}", interval))?;
+        Ok(Duration::from_millis(ms))
+    } else if interval.ends_with('s') {
+        let secs = interval
+            .trim_end_matches('s')
+            .parse::<f64>()
+            .map_err(|_| format!("Invalid seconds: {}", interval))?;
+        Ok(Duration::from_secs_f64(secs))
+    } else {
+        // Default to seconds
+        let secs = interval
+            .parse::<f64>()
+            .map_err(|_| format!("Invalid interval: {}", interval))?;
+        Ok(Duration::from_secs_f64(secs))
+    }
+}
+
+/// Execute a command and return its stdout output
+pub fn exec_command(command: &str) -> Result<String, String> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .output()
+        .map_err(|e| format!("Failed to execute command: {}", e))?;
+
+    // Combine stdout and stderr for full output
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !stderr.is_empty() && !output.status.success() {
+        return Err(format!("{}", stderr.trim()));
+    }
+
+    Ok(stdout.trim().to_string())
+}
+
+/// Setup Ctrl+C handler
+pub fn setup_ctrl_c() -> Arc<AtomicBool> {
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl+C handler");
+
+    running
+}
+
+/// Clear screen and move cursor to top
+pub fn clear_screen() {
+    let mut stdout = io::stdout();
+    stdout
+        .execute(terminal::Clear(terminal::ClearType::All))
+        .ok();
+    stdout.execute(cursor::MoveTo(0, 0)).ok();
+    stdout.flush().ok();
+}
+
+/// Clear the current line and move cursor to beginning
+pub fn clear_line() {
+    let mut stdout = io::stdout();
+    stdout
+        .execute(terminal::Clear(terminal::ClearType::CurrentLine))
+        .ok();
+    stdout.execute(cursor::MoveToColumn(0)).ok();
+    stdout.flush().ok();
+}
+
+/// Move cursor to beginning of line
+pub fn move_to_line_start() {
+    let mut stdout = io::stdout();
+    stdout.execute(cursor::MoveToColumn(0)).ok();
+    stdout.flush().ok();
+}
+
+/// Format a duration as human readable
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Run watch mode - repeatedly execute command and display output
+pub fn render(
+    command: &str,
+    interval: Duration,
+    no_title: bool,
+    differences: bool,
+    exit_on_error: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let running = setup_ctrl_c();
+    let start_time = Instant::now();
+    let mut last_output: Option<String> = None;
+    let mut iteration = 0u64;
+
+    while running.load(Ordering::SeqCst) {
+        iteration += 1;
+        clear_screen();
+
+        // Print header unless no_title
+        if !no_title {
+            let elapsed = format_duration(start_time.elapsed());
+            println!(
+                "\x1b[7m Every {} | {} | Elapsed: {} | Iteration: {} \x1b[0m",
+                format_interval(interval),
+                command,
+                elapsed,
+                iteration
+            );
+            println!();
+        }
+
+        // Execute command
+        match exec_command(command) {
+            Ok(output) => {
+                if differences {
+                    // Show differences from last output
+                    if let Some(ref prev) = last_output {
+                        print_with_differences(prev, &output);
+                    } else {
+                        println!("{}", output);
+                    }
+                    last_output = Some(output);
+                } else {
+                    println!("{}", output);
+                }
+            }
+            Err(e) => {
+                println!("\x1b[31mError: {}\x1b[0m", e);
+                if exit_on_error {
+                    return Err(e.into());
+                }
+            }
+        }
+
+        // Wait for interval, checking for Ctrl+C
+        let sleep_step = Duration::from_millis(100);
+        let mut slept = Duration::ZERO;
+        while slept < interval && running.load(Ordering::SeqCst) {
+            std::thread::sleep(sleep_step);
+            slept += sleep_step;
+        }
+    }
+
+    // Clear status line on exit
+    println!("\n\x1b[2mWatch stopped.\x1b[0m");
+    Ok(())
+}
+
+/// Format interval for display
+fn format_interval(d: Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1000 {
+        format!("{}ms", ms)
+    } else if ms % 1000 == 0 {
+        format!("{}s", ms / 1000)
+    } else {
+        format!("{:.1}s", d.as_secs_f64())
+    }
+}
+
+/// Print output with differences highlighted
+fn print_with_differences(old: &str, new: &str) {
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+
+    for (i, new_line) in new_lines.iter().enumerate() {
+        if i >= old_lines.len() {
+            // New line added
+            println!("\x1b[32m{}\x1b[0m", new_line);
+        } else if old_lines[i] != *new_line {
+            // Line changed
+            println!("\x1b[33m{}\x1b[0m", new_line);
+        } else {
+            println!("{}", new_line);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_interval_ms() {
+        assert_eq!(parse_interval("500ms").unwrap(), Duration::from_millis(500));
+        assert_eq!(
+            parse_interval("1000ms").unwrap(),
+            Duration::from_millis(1000)
+        );
+    }
+
+    #[test]
+    fn test_parse_interval_seconds() {
+        assert_eq!(parse_interval("1s").unwrap(), Duration::from_secs(1));
+        assert_eq!(
+            parse_interval("2.5s").unwrap(),
+            Duration::from_secs_f64(2.5)
+        );
+        assert_eq!(parse_interval("1").unwrap(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_exec_command() {
+        let result = exec_command("echo 42");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "42");
+    }
+
+    #[test]
+    fn test_exec_command_failure() {
+        // Use a command that outputs to stderr and fails
+        let result = exec_command("echo 'error message' >&2 && exit 1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_interval() {
+        assert_eq!(format_interval(Duration::from_millis(500)), "500ms");
+        assert_eq!(format_interval(Duration::from_secs(1)), "1s");
+        assert_eq!(format_interval(Duration::from_secs(2)), "2s");
+    }
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(Duration::from_secs(30)), "30s");
+        assert_eq!(format_duration(Duration::from_secs(90)), "1m 30s");
+        assert_eq!(format_duration(Duration::from_secs(3700)), "1h 1m");
+    }
+}

--- a/tests/e2e_watch.rs
+++ b/tests/e2e_watch.rs
@@ -1,0 +1,39 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn test_watch_help() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.arg("watch").arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Watch mode"))
+        .stdout(predicate::str::contains("--interval"))
+        .stdout(predicate::str::contains("--differences"))
+        .stdout(predicate::str::contains("--no-title"))
+        .stdout(predicate::str::contains("--exit-on-error"));
+}
+
+#[test]
+fn test_watch_requires_command() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.arg("watch");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_watch_invalid_interval() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.arg("watch")
+        .arg("echo test")
+        .arg("--interval")
+        .arg("invalid");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid"));
+}


### PR DESCRIPTION
## Summary
Implement watch mode that repeatedly executes commands and displays output, similar to the Unix `watch` command but integrated with termgfx styling.

Closes #60

## Changes
- Add `src/output/watch.rs` with interval parsing, command execution, and live display loop
- Add Watch command to CLI with flexible options
- Add E2E tests for watch command
- Support flexible intervals: 1s, 500ms, 2.5s

## Features
- **Live refresh**: Repeatedly execute command at specified interval
- **Header display**: Shows command, interval, elapsed time, iteration count
- **Ctrl+C handling**: Graceful exit with status message
- **Difference highlighting**: Yellow/green highlighting for changed/new lines
- **Exit on error**: Optional early exit when command fails

## CLI Options
```
termgfx watch <COMMAND> [OPTIONS]

Options:
  -i, --interval <INTERVAL>    Refresh interval (default: 2s)
  -n, --no-title               Don't show header
  -d, --differences            Highlight differences between updates
  -e, --exit-on-error          Exit on command error
```

## Examples
```bash
# Watch date every second
termgfx watch "date" --interval 1s

# Monitor disk usage with difference highlighting
termgfx watch "df -h" --interval 5s --differences

# Watch without header
termgfx watch "uptime" --interval 2s --no-title
```

## Test Plan
- [x] Unit tests for interval parsing (ms, s, decimal)
- [x] Unit tests for command execution
- [x] E2E tests for help, required args, invalid intervals
- [x] All tests pass