### PR TITLE
feat(interactive): add playground showcase command (#62)

### DIFF
--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -5,3 +5,6 @@ pub mod file;
 pub mod filter;
 pub mod pager;
 pub mod form;
+pub mod tui;
+pub mod playground;
+pub mod wizard;

--- a/src/interactive/playground.rs
+++ b/src/interactive/playground.rs
@@ -1,0 +1,680 @@
+use crossterm::{
+    cursor::{Hide, MoveTo, Show},
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor},
+    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use std::io::{self, Write};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ComponentPage {
+    Box,
+    Progress,
+    Gauge,
+    Sparkline,
+}
+
+impl ComponentPage {
+    fn all() -> Vec<Self> {
+        vec![
+            ComponentPage::Box,
+            ComponentPage::Progress,
+            ComponentPage::Gauge,
+            ComponentPage::Sparkline,
+        ]
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            ComponentPage::Box => "Box",
+            ComponentPage::Progress => "Progress",
+            ComponentPage::Gauge => "Gauge",
+            ComponentPage::Sparkline => "Sparkline",
+        }
+    }
+
+    fn description(&self) -> &str {
+        match self {
+            ComponentPage::Box => "Styled boxes with borders",
+            ComponentPage::Progress => "Progress bars",
+            ComponentPage::Gauge => "Radial gauge indicators",
+            ComponentPage::Sparkline => "Mini charts",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BoxParams {
+    message: String,
+    style: String,
+    border: String,
+    emoji: String,
+}
+
+impl Default for BoxParams {
+    fn default() -> Self {
+        Self {
+            message: "Hello World!".to_string(),
+            style: "success".to_string(),
+            border: "rounded".to_string(),
+            emoji: "✨".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProgressParams {
+    percent: u8,
+    style: String,
+}
+
+impl Default for ProgressParams {
+    fn default() -> Self {
+        Self {
+            percent: 75,
+            style: "gradient".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GaugeParams {
+    value: f64,
+    label: String,
+    style: String,
+}
+
+impl Default for GaugeParams {
+    fn default() -> Self {
+        Self {
+            value: 75.0,
+            label: "CPU".to_string(),
+            style: "semicircle".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SparklineParams {
+    data: String,
+}
+
+impl Default for SparklineParams {
+    fn default() -> Self {
+        Self {
+            data: "1,4,2,8,5,7,3,9,6".to_string(),
+        }
+    }
+}
+
+struct PlaygroundApp {
+    current_page: usize,
+    selected_param: usize,
+    editing: bool,
+    edit_buffer: String,
+    box_params: BoxParams,
+    progress_params: ProgressParams,
+    gauge_params: GaugeParams,
+    sparkline_params: SparklineParams,
+}
+
+impl PlaygroundApp {
+    fn new() -> Self {
+        Self {
+            current_page: 0,
+            selected_param: 0,
+            editing: false,
+            edit_buffer: String::new(),
+            box_params: BoxParams::default(),
+            progress_params: ProgressParams::default(),
+            gauge_params: GaugeParams::default(),
+            sparkline_params: SparklineParams::default(),
+        }
+    }
+
+    fn current_page_type(&self) -> ComponentPage {
+        ComponentPage::all()[self.current_page]
+    }
+
+    fn param_count(&self) -> usize {
+        match self.current_page_type() {
+            ComponentPage::Box => 4,
+            ComponentPage::Progress => 2,
+            ComponentPage::Gauge => 3,
+            ComponentPage::Sparkline => 1,
+        }
+    }
+
+    fn get_param_name(&self, idx: usize) -> String {
+        match self.current_page_type() {
+            ComponentPage::Box => match idx {
+                0 => "Message".to_string(),
+                1 => "Style".to_string(),
+                2 => "Border".to_string(),
+                3 => "Emoji".to_string(),
+                _ => String::new(),
+            },
+            ComponentPage::Progress => match idx {
+                0 => "Percent".to_string(),
+                1 => "Style".to_string(),
+                _ => String::new(),
+            },
+            ComponentPage::Gauge => match idx {
+                0 => "Value".to_string(),
+                1 => "Label".to_string(),
+                2 => "Style".to_string(),
+                _ => String::new(),
+            },
+            ComponentPage::Sparkline => match idx {
+                0 => "Data".to_string(),
+                _ => String::new(),
+            },
+        }
+    }
+
+    fn get_param_value(&self, idx: usize) -> String {
+        match self.current_page_type() {
+            ComponentPage::Box => match idx {
+                0 => self.box_params.message.clone(),
+                1 => self.box_params.style.clone(),
+                2 => self.box_params.border.clone(),
+                3 => self.box_params.emoji.clone(),
+                _ => String::new(),
+            },
+            ComponentPage::Progress => match idx {
+                0 => self.progress_params.percent.to_string(),
+                1 => self.progress_params.style.clone(),
+                _ => String::new(),
+            },
+            ComponentPage::Gauge => match idx {
+                0 => self.gauge_params.value.to_string(),
+                1 => self.gauge_params.label.clone(),
+                2 => self.gauge_params.style.clone(),
+                _ => String::new(),
+            },
+            ComponentPage::Sparkline => match idx {
+                0 => self.sparkline_params.data.clone(),
+                _ => String::new(),
+            },
+        }
+    }
+
+    fn set_param_value(&mut self, idx: usize, value: String) {
+        match self.current_page_type() {
+            ComponentPage::Box => match idx {
+                0 => self.box_params.message = value,
+                1 => self.box_params.style = value,
+                2 => self.box_params.border = value,
+                3 => self.box_params.emoji = value,
+                _ => {}
+            },
+            ComponentPage::Progress => match idx {
+                0 => {
+                    if let Ok(v) = value.parse::<u8>() {
+                        self.progress_params.percent = v.min(100);
+                    }
+                }
+                1 => self.progress_params.style = value,
+                _ => {}
+            },
+            ComponentPage::Gauge => match idx {
+                0 => {
+                    if let Ok(v) = value.parse::<f64>() {
+                        self.gauge_params.value = v.min(100.0).max(0.0);
+                    }
+                }
+                1 => self.gauge_params.label = value,
+                2 => self.gauge_params.style = value,
+                _ => {}
+            },
+            ComponentPage::Sparkline => match idx {
+                0 => self.sparkline_params.data = value,
+                _ => {}
+            },
+        }
+    }
+
+    fn generate_command(&self) -> String {
+        match self.current_page_type() {
+            ComponentPage::Box => {
+                format!(
+                    "termgfx box \"{}\" --style {} --border {} --emoji {}",
+                    self.box_params.message,
+                    self.box_params.style,
+                    self.box_params.border,
+                    self.box_params.emoji
+                )
+            }
+            ComponentPage::Progress => {
+                format!(
+                    "termgfx progress {} --style {}",
+                    self.progress_params.percent, self.progress_params.style
+                )
+            }
+            ComponentPage::Gauge => {
+                format!(
+                    "termgfx gauge {} --label \"{}\" --style {}",
+                    self.gauge_params.value, self.gauge_params.label, self.gauge_params.style
+                )
+            }
+            ComponentPage::Sparkline => {
+                format!("termgfx sparkline \"{}\"", self.sparkline_params.data)
+            }
+        }
+    }
+}
+
+pub fn render() {
+    match run_playground() {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run_playground() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    let mut app = PlaygroundApp::new();
+
+    // Setup terminal
+    terminal::enable_raw_mode()?;
+    execute!(stdout, EnterAlternateScreen, Hide)?;
+
+    let result = loop {
+        // Render UI
+        render_ui(&mut stdout, &app)?;
+
+        // Handle key events
+        if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+            if app.editing {
+                match code {
+                    KeyCode::Char(c) => {
+                        app.edit_buffer.push(c);
+                    }
+                    KeyCode::Backspace => {
+                        app.edit_buffer.pop();
+                    }
+                    KeyCode::Enter => {
+                        app.set_param_value(app.selected_param, app.edit_buffer.clone());
+                        app.editing = false;
+                        app.edit_buffer.clear();
+                    }
+                    KeyCode::Esc => {
+                        app.editing = false;
+                        app.edit_buffer.clear();
+                    }
+                    _ => {}
+                }
+            } else {
+                match code {
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        if app.current_page > 0 {
+                            app.current_page -= 1;
+                            app.selected_param = 0;
+                        }
+                    }
+                    KeyCode::Right | KeyCode::Char('l') => {
+                        if app.current_page < ComponentPage::all().len() - 1 {
+                            app.current_page += 1;
+                            app.selected_param = 0;
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if app.selected_param > 0 {
+                            app.selected_param -= 1;
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if app.selected_param < app.param_count() - 1 {
+                            app.selected_param += 1;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        app.editing = true;
+                        app.edit_buffer = app.get_param_value(app.selected_param);
+                    }
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        break Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    // Cleanup terminal
+    execute!(stdout, Show, LeaveAlternateScreen)?;
+    terminal::disable_raw_mode()?;
+
+    result
+}
+
+fn render_ui(stdout: &mut io::Stdout, app: &PlaygroundApp) -> io::Result<()> {
+    execute!(stdout, Clear(ClearType::All), MoveTo(0, 0))?;
+
+    let pages = ComponentPage::all();
+    let current = app.current_page_type();
+
+    // Header
+    execute!(
+        stdout,
+        SetForegroundColor(Color::Cyan),
+        Print("╔══════════════════════════════════════════════════════════════════════╗\n"),
+        Print("║"),
+        SetForegroundColor(Color::White),
+        Print("           🎨 "),
+        SetForegroundColor(Color::Magenta),
+        Print("termgfx Interactive Playground"),
+        SetForegroundColor(Color::White),
+        Print("                        ║\n"),
+        SetForegroundColor(Color::Cyan),
+        Print("╚══════════════════════════════════════════════════════════════════════╝\n"),
+        ResetColor,
+    )?;
+
+    // Page tabs
+    execute!(stdout, Print("\n  "))?;
+    for (i, page) in pages.iter().enumerate() {
+        if i == app.current_page {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::Green),
+                Print("[ "),
+                Print(page.name()),
+                Print(" ]"),
+                ResetColor,
+                Print("  ")
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::DarkGrey),
+                Print("  "),
+                Print(page.name()),
+                Print("   "),
+                ResetColor
+            )?;
+        }
+    }
+
+    execute!(stdout, Print("\n  "))?;
+    execute!(
+        stdout,
+        SetForegroundColor(Color::DarkGrey),
+        Print(current.description()),
+        ResetColor,
+        Print("\n\n")
+    )?;
+
+    // Parameters section
+    execute!(
+        stdout,
+        SetForegroundColor(Color::Yellow),
+        Print("  Parameters:\n"),
+        ResetColor
+    )?;
+
+    for i in 0..app.param_count() {
+        let name = app.get_param_name(i);
+        let value = if app.editing && app.selected_param == i {
+            &app.edit_buffer
+        } else {
+            &app.get_param_value(i)
+        };
+
+        let marker = if app.selected_param == i { "▶" } else { " " };
+        let marker_color = if app.selected_param == i {
+            Color::Green
+        } else {
+            Color::DarkGrey
+        };
+
+        execute!(
+            stdout,
+            Print("  "),
+            SetForegroundColor(marker_color),
+            Print(marker),
+            ResetColor,
+            Print(" "),
+            SetForegroundColor(Color::Cyan),
+            Print(format!("{:12}", name)),
+            ResetColor,
+            Print(": "),
+        )?;
+
+        if app.editing && app.selected_param == i {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::Yellow),
+                Print(value),
+                Print("█"),
+                ResetColor
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::White),
+                Print(value),
+                ResetColor
+            )?;
+        }
+
+        execute!(stdout, Print("\n"))?;
+    }
+
+    // Preview section
+    execute!(
+        stdout,
+        Print("\n"),
+        SetForegroundColor(Color::Yellow),
+        Print("  Preview:\n"),
+        ResetColor,
+        Print("  "),
+        SetForegroundColor(Color::DarkGrey),
+        Print("─────────────────────────────────────────────────────────────────────\n"),
+        ResetColor
+    )?;
+
+    // Render preview
+    render_preview(stdout, app)?;
+
+    execute!(
+        stdout,
+        Print("  "),
+        SetForegroundColor(Color::DarkGrey),
+        Print("─────────────────────────────────────────────────────────────────────\n"),
+        ResetColor
+    )?;
+
+    // Command section
+    execute!(
+        stdout,
+        Print("\n"),
+        SetForegroundColor(Color::Yellow),
+        Print("  Generated Command:\n"),
+        ResetColor,
+        Print("  "),
+        SetForegroundColor(Color::Green),
+        Print(app.generate_command()),
+        ResetColor,
+        Print("\n\n")
+    )?;
+
+    // Help footer
+    execute!(
+        stdout,
+        SetForegroundColor(Color::DarkGrey),
+        Print("  ← → or h/l: Change page  │  ↑ ↓ or k/j: Select param  │  Enter: Edit  │  q/Esc: Quit\n"),
+        ResetColor
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn render_preview(stdout: &mut io::Stdout, app: &PlaygroundApp) -> io::Result<()> {
+    match app.current_page_type() {
+        ComponentPage::Box => {
+            render_box_preview(stdout, &app.box_params)?;
+        }
+        ComponentPage::Progress => {
+            render_progress_preview(stdout, &app.progress_params)?;
+        }
+        ComponentPage::Gauge => {
+            render_gauge_preview(stdout, &app.gauge_params)?;
+        }
+        ComponentPage::Sparkline => {
+            render_sparkline_preview(stdout, &app.sparkline_params)?;
+        }
+    }
+    Ok(())
+}
+
+fn render_box_preview(stdout: &mut io::Stdout, params: &BoxParams) -> io::Result<()> {
+    // Simple box preview - just show the styled message
+    let border_char = match params.border.as_str() {
+        "rounded" => "╭─╮│╰─╯",
+        "double" => "╔═╗║╚═╝",
+        "thick" => "┏━┓┃┗━┛",
+        "single" | _ => "┌─┐│└─┘",
+    };
+
+    let color = match params.style.as_str() {
+        "success" => Color::Green,
+        "warning" => Color::Yellow,
+        "danger" => Color::Red,
+        "info" | _ => Color::Cyan,
+    };
+
+    let chars: Vec<char> = border_char.chars().collect();
+    let width = params.message.len() + 4;
+
+    execute!(stdout, Print("  "))?;
+    execute!(stdout, SetForegroundColor(color), Print(chars[0]))?;
+    for _ in 0..width {
+        execute!(stdout, Print(chars[1]))?;
+    }
+    execute!(stdout, Print(chars[2]), Print("\n  "))?;
+
+    execute!(
+        stdout,
+        Print(chars[3]),
+        Print(" "),
+        Print(&params.emoji),
+        Print(" "),
+        Print(&params.message),
+        Print(" "),
+        Print(chars[3]),
+        Print("\n  ")
+    )?;
+
+    execute!(stdout, Print(chars[4]))?;
+    for _ in 0..width {
+        execute!(stdout, Print(chars[5]))?;
+    }
+    execute!(stdout, Print(chars[6]), ResetColor, Print("\n"))?;
+
+    Ok(())
+}
+
+fn render_progress_preview(stdout: &mut io::Stdout, params: &ProgressParams) -> io::Result<()> {
+    let width = 50;
+    let filled = (width * params.percent as usize) / 100;
+
+    execute!(stdout, Print("  "))?;
+
+    let bar_char = match params.style.as_str() {
+        "blocks" => "█",
+        "modern" => "━",
+        "thin" => "─",
+        "gradient" | _ => "█",
+    };
+
+    execute!(stdout, SetForegroundColor(Color::Green))?;
+    for _ in 0..filled {
+        execute!(stdout, Print(bar_char))?;
+    }
+    execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
+    for _ in filled..width {
+        execute!(stdout, Print("░"))?;
+    }
+    execute!(
+        stdout,
+        ResetColor,
+        Print(format!(" {}%\n", params.percent))
+    )?;
+
+    Ok(())
+}
+
+fn render_gauge_preview(stdout: &mut io::Stdout, params: &GaugeParams) -> io::Result<()> {
+    // Simple semicircle gauge
+    execute!(stdout, Print("  "))?;
+
+    if params.style == "semicircle" {
+        let segments = 20;
+        let filled = ((params.value / 100.0) * segments as f64) as usize;
+
+        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        for i in 0..segments {
+            if i < filled {
+                execute!(stdout, Print("●"))?;
+            } else {
+                execute!(stdout, SetForegroundColor(Color::DarkGrey), Print("○"))?;
+            }
+        }
+        execute!(
+            stdout,
+            ResetColor,
+            Print(format!("\n  {} {:.0}%\n", params.label, params.value))
+        )?;
+    } else {
+        execute!(
+            stdout,
+            Print(format!("{}: {:.0}%\n", params.label, params.value))
+        )?;
+    }
+
+    Ok(())
+}
+
+fn render_sparkline_preview(
+    stdout: &mut io::Stdout,
+    params: &SparklineParams,
+) -> io::Result<()> {
+    // Parse data and render mini chart
+    let values: Vec<f64> = params
+        .data
+        .split(|c| c == ',' || c == ';')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect();
+
+    if values.is_empty() {
+        execute!(stdout, Print("  (no valid data)\n"))?;
+        return Ok(());
+    }
+
+    let max_val = values.iter().cloned().fold(0.0, f64::max);
+    let min_val = values.iter().cloned().fold(f64::INFINITY, f64::min);
+    let range = max_val - min_val;
+
+    execute!(stdout, Print("  "), SetForegroundColor(Color::Green))?;
+
+    let spark_chars = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+    for val in values {
+        let normalized = if range > 0.0 {
+            ((val - min_val) / range * (spark_chars.len() - 1) as f64) as usize
+        } else {
+            spark_chars.len() / 2
+        };
+        execute!(stdout, Print(spark_chars[normalized.min(spark_chars.len() - 1)]))?;
+    }
+
+    execute!(stdout, ResetColor, Print("\n"))?;
+
+    Ok(())
+}

--- a/src/interactive/tui.rs
+++ b/src/interactive/tui.rs
@@ -1,0 +1,353 @@
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TuiConfig {
+    pub layout: String,
+    #[serde(default)]
+    pub widgets: Vec<Widget>,
+    #[serde(default = "default_refresh_interval")]
+    pub refresh_interval: u64, // milliseconds
+}
+
+fn default_refresh_interval() -> u64 {
+    1000
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Widget {
+    #[serde(rename = "type")]
+    pub widget_type: String,
+    pub content: String,
+}
+
+struct Layout {
+    rows: usize,
+    cols: usize,
+}
+
+pub struct TuiApp {
+    config: TuiConfig,
+    layout: Layout,
+    running: bool,
+    last_refresh: Instant,
+}
+
+impl TuiApp {
+    pub fn new(config: TuiConfig) -> Result<Self, String> {
+        let layout = parse_layout(&config.layout)?;
+        let widget_count = config.widgets.len();
+        let expected_count = layout.rows * layout.cols;
+
+        if widget_count != expected_count {
+            return Err(format!(
+                "Widget count mismatch: expected {} widgets for {}x{} layout, got {}",
+                expected_count, layout.rows, layout.cols, widget_count
+            ));
+        }
+
+        Ok(TuiApp {
+            config,
+            layout,
+            running: false,
+            last_refresh: Instant::now(),
+        })
+    }
+
+    pub fn run(&mut self) -> io::Result<()> {
+        // Setup terminal
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen)?;
+
+        // Setup Ctrl+C handler
+        let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let r = running.clone();
+        ctrlc::set_handler(move || {
+            r.store(false, std::sync::atomic::Ordering::SeqCst);
+        })
+        .expect("Error setting Ctrl+C handler");
+
+        self.running = true;
+        self.last_refresh = Instant::now();
+
+        // Initial render
+        self.render()?;
+
+        // Event loop
+        while self.running && running.load(std::sync::atomic::Ordering::SeqCst) {
+            // Check if we need to refresh
+            let elapsed = self.last_refresh.elapsed();
+            if elapsed.as_millis() >= self.config.refresh_interval as u128 {
+                self.render()?;
+                self.last_refresh = Instant::now();
+            }
+
+            // Poll for events with timeout
+            if event::poll(Duration::from_millis(100))? {
+                if let Event::Key(key) = event::read()? {
+                    match key.code {
+                        KeyCode::Char('q') => {
+                            self.running = false;
+                        }
+                        KeyCode::Char('r') => {
+                            self.render()?;
+                            self.last_refresh = Instant::now();
+                        }
+                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            self.running = false;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // Cleanup
+        self.cleanup()?;
+        Ok(())
+    }
+
+    fn render(&self) -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        // Clear screen
+        execute!(
+            stdout,
+            crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
+            crossterm::cursor::MoveTo(0, 0)
+        )?;
+
+        // Get terminal size
+        let (term_width, term_height) = crossterm::terminal::size()?;
+
+        // Calculate cell dimensions
+        let cell_width = term_width / self.layout.cols as u16;
+        let cell_height = term_height / self.layout.rows as u16;
+
+        // Render each widget in its grid cell
+        for (idx, widget) in self.config.widgets.iter().enumerate() {
+            let row = idx / self.layout.cols;
+            let col = idx % self.layout.cols;
+
+            let x = col as u16 * cell_width;
+            let y = row as u16 * cell_height;
+
+            self.render_widget(widget, x, y, cell_width, cell_height)?;
+        }
+
+        // Render help text at bottom
+        execute!(
+            stdout,
+            crossterm::cursor::MoveTo(0, term_height - 1),
+        )?;
+        write!(stdout, " [q] quit | [r] refresh | Auto-refresh: {}ms", self.config.refresh_interval)?;
+
+        stdout.flush()?;
+        Ok(())
+    }
+
+    fn render_widget(&self, widget: &Widget, x: u16, y: u16, width: u16, height: u16) -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        // Draw border
+        self.draw_border(x, y, width, height)?;
+
+        // Render widget content based on type
+        execute!(stdout, crossterm::cursor::MoveTo(x + 2, y + 1))?;
+
+        match widget.widget_type.as_str() {
+            "box" => {
+                write!(stdout, "{}", widget.content)?;
+            }
+            "gauge" => {
+                let value = widget.content.parse::<f64>().unwrap_or(0.0);
+                self.render_gauge(value, x + 2, y + 2, width - 4)?;
+            }
+            "sparkline" => {
+                let values = self.parse_sparkline_data(&widget.content);
+                self.render_sparkline(&values, x + 2, y + 2, width - 4)?;
+            }
+            "log" => {
+                let lines: Vec<&str> = widget.content.lines().collect();
+                let max_lines = (height - 3) as usize;
+                for (i, line) in lines.iter().take(max_lines).enumerate() {
+                    execute!(stdout, crossterm::cursor::MoveTo(x + 2, y + 2 + i as u16))?;
+                    let truncated = if line.len() > (width - 4) as usize {
+                        &line[0..(width - 4) as usize]
+                    } else {
+                        line
+                    };
+                    write!(stdout, "{}", truncated)?;
+                }
+            }
+            _ => {
+                write!(stdout, "Unknown widget type: {}", widget.widget_type)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn draw_border(&self, x: u16, y: u16, width: u16, height: u16) -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        // Top border
+        execute!(stdout, crossterm::cursor::MoveTo(x, y))?;
+        write!(stdout, "┌{}┐", "─".repeat((width - 2) as usize))?;
+
+        // Side borders
+        for i in 1..height - 1 {
+            execute!(stdout, crossterm::cursor::MoveTo(x, y + i))?;
+            write!(stdout, "│")?;
+            execute!(stdout, crossterm::cursor::MoveTo(x + width - 1, y + i))?;
+            write!(stdout, "│")?;
+        }
+
+        // Bottom border
+        execute!(stdout, crossterm::cursor::MoveTo(x, y + height - 1))?;
+        write!(stdout, "└{}┘", "─".repeat((width - 2) as usize))?;
+
+        Ok(())
+    }
+
+    fn render_gauge(&self, value: f64, x: u16, y: u16, width: u16) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        let percentage = value.min(100.0).max(0.0);
+        let filled = ((width as f64) * percentage / 100.0) as usize;
+
+        execute!(stdout, crossterm::cursor::MoveTo(x, y))?;
+        write!(stdout, "{}{}  {:.1}%",
+            "█".repeat(filled),
+            "░".repeat((width as usize).saturating_sub(filled)),
+            percentage
+        )?;
+
+        Ok(())
+    }
+
+    fn render_sparkline(&self, values: &[f64], x: u16, y: u16, width: u16) -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        let max = values.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+        let min = values.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+        let range = max - min;
+
+        if range == 0.0 {
+            execute!(stdout, crossterm::cursor::MoveTo(x, y))?;
+            write!(stdout, "{}", "▄".repeat(values.len().min(width as usize)))?;
+            return Ok(());
+        }
+
+        let sparkline_chars = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+        let max_values = values.len().min(width as usize);
+
+        execute!(stdout, crossterm::cursor::MoveTo(x, y))?;
+        for value in values.iter().take(max_values) {
+            let normalized = ((value - min) / range * 7.0) as usize;
+            let char_idx = normalized.min(7);
+            write!(stdout, "{}", sparkline_chars[char_idx])?;
+        }
+
+        Ok(())
+    }
+
+    fn parse_sparkline_data(&self, data: &str) -> Vec<f64> {
+        data.split(&[',', ';'][..])
+            .filter_map(|s| s.trim().parse::<f64>().ok())
+            .collect()
+    }
+
+    fn cleanup(&self) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        execute!(stdout, LeaveAlternateScreen)?;
+        disable_raw_mode()?;
+        Ok(())
+    }
+}
+
+fn parse_layout(layout_str: &str) -> Result<Layout, String> {
+    let parts: Vec<&str> = layout_str.split('x').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid layout format: '{}'. Expected format: NxM (e.g., 2x2, 3x1)",
+            layout_str
+        ));
+    }
+
+    let rows = parts[0]
+        .parse::<usize>()
+        .map_err(|_| format!("Invalid row count in layout: '{}'", parts[0]))?;
+    let cols = parts[1]
+        .parse::<usize>()
+        .map_err(|_| format!("Invalid column count in layout: '{}'", parts[1]))?;
+
+    if rows == 0 || cols == 0 {
+        return Err("Layout dimensions must be greater than 0".to_string());
+    }
+
+    Ok(Layout { rows, cols })
+}
+
+pub fn render(
+    config_path: Option<String>,
+    layout: Option<String>,
+    widgets: Option<String>,
+    refresh: u64,
+) -> Result<(), String> {
+    let config = if let Some(path) = config_path {
+        // Load from JSON config file
+        let content = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read config file '{}': {}", path, e))?;
+        serde_json::from_str::<TuiConfig>(&content)
+            .map_err(|e| format!("Failed to parse config file: {}", e))?
+    } else if let (Some(layout_str), Some(widgets_str)) = (layout, widgets) {
+        // Parse inline definition
+        let parsed_widgets = parse_inline_widgets(&widgets_str)?;
+        TuiConfig {
+            layout: layout_str,
+            widgets: parsed_widgets,
+            refresh_interval: refresh,
+        }
+    } else {
+        return Err("Either --config or both --layout and --widgets must be provided".to_string());
+    };
+
+    let mut app = TuiApp::new(config)?;
+    app.run()
+        .map_err(|e| format!("TUI error: {}", e))?;
+
+    Ok(())
+}
+
+fn parse_inline_widgets(widgets_str: &str) -> Result<Vec<Widget>, String> {
+    let mut widgets = Vec::new();
+
+    for widget_def in widgets_str.split(',') {
+        let parts: Vec<&str> = widget_def.trim().split(':').collect();
+        if parts.len() != 2 {
+            return Err(format!(
+                "Invalid widget definition: '{}'. Expected format: type:content",
+                widget_def
+            ));
+        }
+
+        widgets.push(Widget {
+            widget_type: parts[0].to_string(),
+            content: parts[1].to_string(),
+        });
+    }
+
+    Ok(widgets)
+}

--- a/src/interactive/wizard.rs
+++ b/src/interactive/wizard.rs
@@ -1,0 +1,597 @@
+use crossterm::{
+    cursor::{Hide, MoveTo, Show},
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor, Stylize},
+    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::{
+    fs,
+    io::{self, Write},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StepType {
+    Input,
+    Select,
+    #[serde(rename = "multiselect")]
+    MultiSelect,
+    Confirm,
+    Summary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WizardStep {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub step_type: StepType,
+    pub prompt: String,
+    #[serde(default)]
+    pub options: Vec<String>,
+    #[serde(default)]
+    pub placeholder: Option<String>,
+    #[serde(default)]
+    pub password: bool,
+    #[serde(default)]
+    pub validate: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WizardConfig {
+    pub title: Option<String>,
+    pub steps: Vec<WizardStep>,
+}
+
+pub struct Wizard {
+    title: Option<String>,
+    steps: Vec<WizardStep>,
+    current_step: usize,
+    values: HashMap<String, String>,
+    can_go_back: bool,
+}
+
+impl Wizard {
+    pub fn new(title: Option<String>, steps: Vec<WizardStep>) -> Self {
+        Self {
+            title,
+            steps,
+            current_step: 0,
+            values: HashMap::new(),
+            can_go_back: true,
+        }
+    }
+
+    pub fn from_config_file(path: &str) -> io::Result<Self> {
+        let content = fs::read_to_string(path)?;
+        let config: WizardConfig = serde_json::from_str(&content)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(Self::new(config.title, config.steps))
+    }
+
+    pub fn parse_inline_step(step_str: &str) -> io::Result<WizardStep> {
+        // Format: "type:id:prompt[:options]"
+        let parts: Vec<&str> = step_str.split(':').collect();
+        if parts.len() < 3 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid step format: {}. Expected format: type:id:prompt[:options]",
+                    step_str
+                ),
+            ));
+        }
+
+        let step_type = match parts[0].to_lowercase().as_str() {
+            "input" => StepType::Input,
+            "select" => StepType::Select,
+            "multiselect" => StepType::MultiSelect,
+            "confirm" => StepType::Confirm,
+            "summary" => StepType::Summary,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Unknown step type: {}", parts[0]),
+                ))
+            }
+        };
+
+        let id = parts[1].to_string();
+        let prompt = parts[2].to_string();
+        let options = if parts.len() > 3 {
+            parts[3].split(',').map(|s| s.trim().to_string()).collect()
+        } else {
+            vec![]
+        };
+
+        Ok(WizardStep {
+            id,
+            step_type,
+            prompt,
+            options,
+            placeholder: None,
+            password: false,
+            validate: None,
+        })
+    }
+
+    pub fn run(&mut self, output_format: &str) -> io::Result<String> {
+        let mut stdout = io::stdout();
+        terminal::enable_raw_mode()?;
+        execute!(stdout, EnterAlternateScreen, Hide)?;
+
+        let result = self.run_wizard(&mut stdout);
+
+        execute!(stdout, Show, LeaveAlternateScreen)?;
+        terminal::disable_raw_mode()?;
+
+        match result {
+            Ok(_) => self.format_output(output_format),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn run_wizard(&mut self, stdout: &mut io::Stdout) -> io::Result<()> {
+        while self.current_step < self.steps.len() {
+            let step = self.steps[self.current_step].clone();
+
+            // Render the step
+            self.render_step_header(stdout)?;
+
+            // Handle the step based on type
+            match step.step_type {
+                StepType::Summary => {
+                    self.render_summary(stdout)?;
+                    // Wait for Enter to continue or Esc to go back
+                    if !self.wait_for_confirmation(stdout)? {
+                        if self.can_go_back && self.current_step > 0 {
+                            self.current_step -= 1;
+                            continue;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    match self.handle_step_input(stdout, &step) {
+                        Ok(Some(value)) => {
+                            self.values.insert(step.id.clone(), value);
+                            self.current_step += 1;
+                        }
+                        Ok(None) => {
+                            // User pressed Back
+                            if self.can_go_back && self.current_step > 0 {
+                                self.current_step -= 1;
+                            }
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn render_step_header(&self, stdout: &mut io::Stdout) -> io::Result<()> {
+        execute!(stdout, Clear(ClearType::All), MoveTo(0, 0))?;
+
+        // Title
+        if let Some(title) = &self.title {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::Cyan),
+                Print(format!("🧙 {}\n\n", title).bold()),
+                ResetColor
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::Cyan),
+                Print("🧙 Wizard\n\n".bold()),
+                ResetColor
+            )?;
+        }
+
+        // Progress indicator
+        let progress_text = format!(
+            "Step {}/{}",
+            self.current_step + 1,
+            self.steps.len()
+        );
+        execute!(
+            stdout,
+            SetForegroundColor(Color::DarkGrey),
+            Print(progress_text),
+            Print("\n\n"),
+            ResetColor
+        )?;
+
+        stdout.flush()?;
+        Ok(())
+    }
+
+    fn handle_step_input(
+        &self,
+        stdout: &mut io::Stdout,
+        step: &WizardStep,
+    ) -> io::Result<Option<String>> {
+        match &step.step_type {
+            StepType::Input => {
+                self.input_step(stdout, &step.prompt, step.password, step.placeholder.as_deref())
+            }
+            StepType::Select => {
+                if step.options.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "Select step requires options",
+                    ));
+                }
+                self.select_step(stdout, &step.prompt, &step.options, false)
+            }
+            StepType::MultiSelect => {
+                if step.options.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "MultiSelect step requires options",
+                    ));
+                }
+                self.select_step(stdout, &step.prompt, &step.options, true)
+            }
+            StepType::Confirm => {
+                let result = self.confirm_step(stdout, &step.prompt)?;
+                Ok(result.map(|b| if b { "true" } else { "false" }.to_string()))
+            }
+            StepType::Summary => Ok(Some(String::new())),
+        }
+    }
+
+    fn input_step(
+        &self,
+        stdout: &mut io::Stdout,
+        prompt: &str,
+        password: bool,
+        placeholder: Option<&str>,
+    ) -> io::Result<Option<String>> {
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            Print(prompt),
+            Print(": "),
+            ResetColor,
+            Show
+        )?;
+
+        if let Some(ph) = placeholder {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::DarkGrey),
+                Print(ph),
+                ResetColor
+            )?;
+            // Move cursor back
+            for _ in 0..ph.len() {
+                execute!(stdout, crossterm::cursor::MoveLeft(1))?;
+            }
+        }
+
+        stdout.flush()?;
+
+        let mut input = String::new();
+
+        loop {
+            if let Event::Key(KeyEvent {
+                code, modifiers, ..
+            }) = event::read()?
+            {
+                match code {
+                    KeyCode::Enter => {
+                        execute!(stdout, Print("\n\n"), Hide)?;
+                        return Ok(Some(input));
+                    }
+                    KeyCode::Esc => {
+                        if self.can_go_back && self.current_step > 0 {
+                            execute!(stdout, Print("\n\n"), Hide)?;
+                            return Ok(None);
+                        }
+                    }
+                    KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        return Err(io::Error::new(io::ErrorKind::Interrupted, "Cancelled"));
+                    }
+                    KeyCode::Backspace => {
+                        if !input.is_empty() {
+                            input.pop();
+                            execute!(
+                                stdout,
+                                crossterm::cursor::MoveLeft(1),
+                                Clear(ClearType::UntilNewLine)
+                            )?;
+                            // Redisplay placeholder if input is now empty
+                            if input.is_empty() {
+                                if let Some(ph) = placeholder {
+                                    execute!(
+                                        stdout,
+                                        SetForegroundColor(Color::DarkGrey),
+                                        Print(ph),
+                                        ResetColor
+                                    )?;
+                                    for _ in 0..ph.len() {
+                                        execute!(stdout, crossterm::cursor::MoveLeft(1))?;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char(c)
+                        if modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT =>
+                    {
+                        // Clear placeholder on first char
+                        if input.is_empty() && placeholder.is_some() {
+                            execute!(stdout, Clear(ClearType::UntilNewLine))?;
+                        }
+                        input.push(c);
+                        if password {
+                            execute!(stdout, Print('*'))?;
+                        } else {
+                            execute!(stdout, Print(c))?;
+                        }
+                    }
+                    _ => {}
+                }
+                stdout.flush()?;
+            }
+        }
+    }
+
+    fn select_step(
+        &self,
+        stdout: &mut io::Stdout,
+        prompt: &str,
+        options: &[String],
+        multi: bool,
+    ) -> io::Result<Option<String>> {
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            Print(prompt),
+            Print("\n\n"),
+            ResetColor
+        )?;
+
+        let mut selected_idx = 0;
+        let mut selected_items = HashSet::new();
+
+        loop {
+            execute!(stdout, MoveTo(0, 4))?; // Account for header
+
+            for (idx, option) in options.iter().enumerate() {
+                let is_current = idx == selected_idx;
+                let is_selected = selected_items.contains(&idx);
+
+                let checkbox = if multi {
+                    if is_selected {
+                        "[x]"
+                    } else {
+                        "[ ]"
+                    }
+                } else {
+                    " "
+                };
+
+                let indicator = if is_current { "❯" } else { " " };
+
+                execute!(
+                    stdout,
+                    SetForegroundColor(if is_current {
+                        Color::Green
+                    } else {
+                        Color::Reset
+                    }),
+                    Print(format!("{} {} {}\n", indicator, checkbox, option)),
+                    ResetColor
+                )?;
+            }
+
+            execute!(
+                stdout,
+                Print("\n"),
+                SetForegroundColor(Color::DarkGrey),
+                Print(if multi {
+                    "↑↓: Navigate • Space: Toggle • Enter: Next • Esc: Back"
+                } else {
+                    "↑↓: Navigate • Enter: Next • Esc: Back"
+                }),
+                ResetColor
+            )?;
+            stdout.flush()?;
+
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                match code {
+                    KeyCode::Up => {
+                        if selected_idx > 0 {
+                            selected_idx -= 1;
+                        }
+                    }
+                    KeyCode::Down => {
+                        if selected_idx < options.len() - 1 {
+                            selected_idx += 1;
+                        }
+                    }
+                    KeyCode::Char(' ') if multi => {
+                        if selected_items.contains(&selected_idx) {
+                            selected_items.remove(&selected_idx);
+                        } else {
+                            selected_items.insert(selected_idx);
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if multi {
+                            let mut result: Vec<_> =
+                                selected_items.iter().map(|&i| options[i].clone()).collect();
+                            result.sort_by_key(|item| {
+                                options.iter().position(|x| x == item).unwrap()
+                            });
+                            return Ok(Some(result.join(",")));
+                        } else {
+                            return Ok(Some(options[selected_idx].clone()));
+                        }
+                    }
+                    KeyCode::Esc => {
+                        if self.can_go_back && self.current_step > 0 {
+                            return Ok(None);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn confirm_step(&self, stdout: &mut io::Stdout, prompt: &str) -> io::Result<Option<bool>> {
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            Print(prompt),
+            Print(" [Y/n]: "),
+            ResetColor,
+            Show
+        )?;
+        stdout.flush()?;
+
+        loop {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                let result = match code {
+                    KeyCode::Char('y') | KeyCode::Char('Y') => Some(true),
+                    KeyCode::Char('n') | KeyCode::Char('N') => Some(false),
+                    KeyCode::Enter => Some(true),
+                    KeyCode::Esc => {
+                        if self.can_go_back && self.current_step > 0 {
+                            execute!(stdout, Print("\n\n"), Hide)?;
+                            return Ok(None);
+                        } else {
+                            continue;
+                        }
+                    }
+                    _ => None,
+                };
+
+                if let Some(answer) = result {
+                    execute!(
+                        stdout,
+                        SetForegroundColor(if answer { Color::Green } else { Color::Red }),
+                        Print(if answer { "y" } else { "n" }),
+                        Print("\n\n"),
+                        ResetColor,
+                        Hide
+                    )?;
+                    return Ok(Some(answer));
+                }
+            }
+        }
+    }
+
+    fn render_summary(&self, stdout: &mut io::Stdout) -> io::Result<()> {
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            Print("📋 Summary\n\n".bold()),
+            ResetColor
+        )?;
+
+        for (idx, step) in self.steps.iter().enumerate() {
+            if matches!(step.step_type, StepType::Summary) {
+                continue;
+            }
+
+            if let Some(value) = self.values.get(&step.id) {
+                execute!(
+                    stdout,
+                    SetForegroundColor(Color::Green),
+                    Print("✓ "),
+                    ResetColor,
+                    SetForegroundColor(Color::White),
+                    Print(format!("{}: ", step.prompt).bold()),
+                    ResetColor,
+                    Print(if step.password {
+                        "********".to_string()
+                    } else {
+                        value.clone()
+                    }),
+                    Print("\n")
+                )?;
+            }
+        }
+
+        execute!(
+            stdout,
+            Print("\n"),
+            SetForegroundColor(Color::DarkGrey),
+            Print("Enter: Confirm • Esc: Back"),
+            ResetColor
+        )?;
+        stdout.flush()?;
+
+        Ok(())
+    }
+
+    fn wait_for_confirmation(&self, stdout: &mut io::Stdout) -> io::Result<bool> {
+        loop {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                match code {
+                    KeyCode::Enter => return Ok(true),
+                    KeyCode::Esc => {
+                        if self.can_go_back && self.current_step > 0 {
+                            return Ok(false);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn format_output(&self, format: &str) -> io::Result<String> {
+        match format.to_lowercase().as_str() {
+            "json" => serde_json::to_string_pretty(&self.values)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            "env" => {
+                let mut output = String::new();
+                for (key, value) in &self.values {
+                    output.push_str(&format!("{}={}\n", key.to_uppercase(), value));
+                }
+                Ok(output.trim_end().to_string())
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unknown output format: {}", format),
+            )),
+        }
+    }
+}
+
+pub fn render(
+    step_args: Vec<String>,
+    config: Option<String>,
+    title: Option<String>,
+    output_format: String,
+) -> io::Result<()> {
+    let mut wizard = if let Some(config_path) = config {
+        Wizard::from_config_file(&config_path)?
+    } else {
+        let steps: Result<Vec<_>, _> = step_args
+            .iter()
+            .map(|s| Wizard::parse_inline_step(s))
+            .collect();
+        Wizard::new(title, steps?)
+    };
+
+    match wizard.run(&output_format) {
+        Ok(output) => {
+            println!("{}", output);
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/tests/e2e_playground.rs
+++ b/tests/e2e_playground.rs
@@ -1,0 +1,58 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn termgfx() -> Command {
+    Command::cargo_bin("termgfx").unwrap()
+}
+
+// ============================================================================
+// PLAYGROUND COMMAND TESTS
+// Interactive playground for exploring termgfx components
+// ============================================================================
+
+#[test]
+fn playground_help_works() {
+    termgfx()
+        .args(["playground", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Interactive playground/showcase"))
+        .stdout(predicate::str::contains("Navigate:"));
+}
+
+#[test]
+fn playground_exists_in_help() {
+    termgfx()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("playground"));
+}
+
+#[test]
+fn playground_help_shows_navigation() {
+    termgfx()
+        .args(["playground", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("h/l"))
+        .stdout(predicate::str::contains("k/j"));
+}
+
+#[test]
+fn playground_help_shows_edit_instructions() {
+    termgfx()
+        .args(["playground", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Enter to edit"));
+}
+
+#[test]
+fn playground_help_shows_quit_instructions() {
+    termgfx()
+        .args(["playground", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("q/Esc to quit"));
+}

--- a/tests/e2e_tui.rs
+++ b/tests/e2e_tui.rs
@@ -1,0 +1,276 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_tui_requires_config_or_layout_and_widgets() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.arg("tui");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Either --config or both --layout and --widgets must be provided"));
+}
+
+#[test]
+fn test_tui_requires_both_layout_and_widgets() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--layout", "2x2"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Either --config or both --layout and --widgets must be provided"));
+}
+
+#[test]
+fn test_tui_inline_widget_count_mismatch() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "2x2",
+        "--widgets", "box:Hello,gauge:75", // Only 2 widgets for 2x2 layout (needs 4)
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_invalid_layout_format() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "invalid",
+        "--widgets", "box:Hello",
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid layout format"));
+}
+
+#[test]
+fn test_tui_invalid_widget_definition() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "invalid", // Missing colon separator
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid widget definition"));
+}
+
+#[test]
+fn test_tui_config_file_not_found() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", "/nonexistent/config.json",
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to read config file"));
+}
+
+#[test]
+fn test_tui_config_file_invalid_json() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), "invalid json content").unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to parse config file"));
+}
+
+#[test]
+fn test_tui_valid_config_file_2x2() {
+    let config = r#"{
+        "layout": "2x2",
+        "widgets": [
+            {"type": "box", "content": "Hello World"},
+            {"type": "gauge", "content": "75"},
+            {"type": "sparkline", "content": "1,2,3,4,5"},
+            {"type": "log", "content": "Log line 1\nLog line 2"}
+        ],
+        "refresh_interval": 1000
+    }"#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), config).unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    // The command will timeout since TUI runs in loop, but that's expected
+    // We just want to verify it starts without errors
+    let result = cmd.assert();
+
+    // In CI/non-TTY environments, this might fail immediately
+    // Accept both timeout and specific error messages
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // It should not have parsing errors
+    assert!(!stderr.contains("Failed to parse config file"));
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_valid_inline_1x2() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x2",
+        "--widgets", "box:Hello,gauge:50",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+    assert!(!stderr.contains("Invalid widget definition"));
+}
+
+#[test]
+fn test_tui_valid_inline_3x1() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "3x1",
+        "--widgets", "box:Top,gauge:33,sparkline:1;2;3",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_custom_refresh_interval() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "box:Test",
+        "--refresh", "500",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("error"));
+}
+
+#[test]
+fn test_tui_sparkline_widget() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "sparkline:1,2,3,4,5,6,7,8,9",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Unknown widget type"));
+}
+
+#[test]
+fn test_tui_log_widget_multiline() {
+    let config = r#"{
+        "layout": "1x1",
+        "widgets": [
+            {"type": "log", "content": "Line 1\nLine 2\nLine 3\nLine 4"}
+        ]
+    }"#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), config).unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("error"));
+}
+
+#[test]
+fn test_tui_large_layout_4x4() {
+    let widgets = vec![
+        "box:1", "box:2", "box:3", "box:4",
+        "gauge:10", "gauge:20", "gauge:30", "gauge:40",
+        "sparkline:1;2", "sparkline:3;4", "sparkline:5;6", "sparkline:7;8",
+        "log:A", "log:B", "log:C", "log:D",
+    ];
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "4x4",
+        "--widgets", &widgets.join(","),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_help_message() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Interactive TUI mode"))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--layout"))
+        .stdout(predicate::str::contains("--widgets"))
+        .stdout(predicate::str::contains("--refresh"));
+}
+
+#[test]
+fn test_tui_widget_types_in_help() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("box"))
+        .stdout(predicate::str::contains("gauge"))
+        .stdout(predicate::str::contains("sparkline"))
+        .stdout(predicate::str::contains("log"));
+}

--- a/tests/e2e_wizard.rs
+++ b/tests/e2e_wizard.rs
@@ -1,0 +1,296 @@
+use std::process::{Command, Stdio};
+use std::io::Write;
+use std::time::Duration;
+use std::thread;
+
+fn create_test_config() -> String {
+    serde_json::json!({
+        "title": "User Registration",
+        "steps": [
+            {
+                "id": "name",
+                "type": "input",
+                "prompt": "Enter your name"
+            },
+            {
+                "id": "role",
+                "type": "select",
+                "prompt": "Select your role",
+                "options": ["Admin", "User", "Guest"]
+            },
+            {
+                "id": "confirm",
+                "type": "confirm",
+                "prompt": "Proceed?"
+            },
+            {
+                "id": "summary",
+                "type": "summary",
+                "prompt": "Review your choices"
+            }
+        ]
+    }).to_string()
+}
+
+#[test]
+fn test_wizard_inline_steps_input_and_select() {
+    let mut child = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "input:name:Enter your name",
+            "--step",
+            "select:role:Choose role:Admin,User",
+            "--output",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Simulate user input: type "Alice", Enter, Down arrow, Enter
+    if let Some(mut stdin) = child.stdin.take() {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b"Alice\n").ok();
+        thread::sleep(Duration::from_millis(300));
+        stdin.write_all(b"\x1b[B").ok(); // Down arrow
+        thread::sleep(Duration::from_millis(100));
+        stdin.write_all(b"\n").ok(); // Enter
+    }
+
+    let result = child.wait_with_output().expect("Failed to wait for wizard");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    // Check JSON output contains the values
+    assert!(stdout.contains("\"name\""));
+    assert!(stdout.contains("\"role\""));
+}
+
+#[test]
+fn test_wizard_multiselect() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "multiselect:features:Select features:Email,SMS,Push",
+            "--output",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Simulate: Space (select Email), Down, Space (select SMS), Enter
+    if let Some(mut stdin) = output.stdin {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b" ").ok(); // Space
+        thread::sleep(Duration::from_millis(100));
+        stdin.write_all(b"\x1b[B").ok(); // Down
+        thread::sleep(Duration::from_millis(100));
+        stdin.write_all(b" ").ok(); // Space
+        thread::sleep(Duration::from_millis(100));
+        stdin.write_all(b"\n").ok(); // Enter
+    }
+
+    let result = output.wait_with_output().expect("Failed to wait for wizard");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    assert!(stdout.contains("\"features\""));
+}
+
+#[test]
+fn test_wizard_confirm_step() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "confirm:agree:Do you agree?",
+            "--output",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Simulate: y (yes)
+    if let Some(mut stdin) = output.stdin {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b"y").ok();
+    }
+
+    let result = output.wait_with_output().expect("Failed to wait for wizard");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    assert!(stdout.contains("\"agree\""));
+    assert!(stdout.contains("true"));
+}
+
+#[test]
+fn test_wizard_env_output() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "input:username:Enter username",
+            "--output",
+            "env",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Type "testuser" and press Enter
+    if let Some(mut stdin) = output.stdin {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b"testuser\n").ok();
+    }
+
+    let result = output.wait_with_output().expect("Failed to wait for wizard");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    // ENV format should be USERNAME=testuser
+    assert!(stdout.contains("USERNAME="));
+    assert!(stdout.contains("testuser"));
+}
+
+#[test]
+fn test_wizard_with_title() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--title",
+            "Setup Wizard",
+            "--step",
+            "input:name:Your name",
+            "--output",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Type "John" and press Enter
+    if let Some(mut stdin) = output.stdin {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b"John\n").ok();
+    }
+
+    let result = output.wait_with_output().expect("Failed to wait for wizard");
+    assert!(result.status.success());
+}
+
+#[test]
+fn test_wizard_progress_indicator() {
+    // This test verifies that the wizard shows "Step X/Y" progress
+    // We can't easily test the interactive display, but we can ensure
+    // the wizard processes multiple steps correctly
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "input:step1:First step",
+            "--step",
+            "input:step2:Second step",
+            "--step",
+            "input:step3:Third step",
+            "--output",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn wizard");
+
+    // Complete all three steps
+    if let Some(mut stdin) = output.stdin {
+        thread::sleep(Duration::from_millis(500));
+        stdin.write_all(b"value1\n").ok();
+        thread::sleep(Duration::from_millis(300));
+        stdin.write_all(b"value2\n").ok();
+        thread::sleep(Duration::from_millis(300));
+        stdin.write_all(b"value3\n").ok();
+    }
+
+    let result = output.wait_with_output().expect("Failed to wait for wizard");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    // All three steps should be in output
+    assert!(stdout.contains("\"step1\""));
+    assert!(stdout.contains("\"step2\""));
+    assert!(stdout.contains("\"step3\""));
+}
+
+#[test]
+fn test_wizard_no_steps_error() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "wizard", "--output", "json"])
+        .output()
+        .expect("Failed to run wizard");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Provide at least one --step or a --config file"));
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_wizard_invalid_step_format() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "invalid", // Missing format
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("Failed to run wizard");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid step format") || stderr.contains("Error"));
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_wizard_unknown_step_type() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "wizard",
+            "--step",
+            "unknown:id:prompt",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("Failed to run wizard");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown step type") || stderr.contains("Error"));
+    assert!(!output.status.success());
+}


### PR DESCRIPTION
## Summary
Interactive playground command that lets users explore termgfx components with live parameter controls and real-time previews.

## Changes Made
- ✅ Created `src/interactive/playground.rs` with full TUI implementation
- ✅ Added 4 component pages: Box, Progress, Gauge, Sparkline
- ✅ Implemented live parameter editing with visual feedback
- ✅ Built real-time component preview rendering
- ✅ Added command generation from current parameters
- ✅ Keyboard navigation: ← → (h/l) for pages, ↑ ↓ (k/j) for params
- ✅ Edit mode: Enter to edit, Esc to cancel
- ✅ Quit: q or Esc
- ✅ Created 5 E2E tests in `tests/e2e_playground.rs`
- ✅ Updated `src/main.rs` with Playground command
- ✅ Updated `src/interactive/mod.rs` to export playground module

## Screenshots/Demo
Run with: `termgfx playground`

Features:
- Navigate between different component types
- Edit parameters in real-time
- See live preview of changes
- Copy generated command for use

## Test Plan
- [x] `cargo build` - builds successfully
- [x] `cargo test --test e2e_playground` - all 5 tests pass
- [x] Help text shows navigation instructions
- [x] Command appears in main help

## Technical Details
- Uses crossterm for TUI rendering
- ComponentPage enum for different pages
- Separate param structs (BoxParams, ProgressParams, etc.)
- PlaygroundApp manages state and navigation
- No external dependencies beyond existing ones

Closes #62