### PR TITLE
feat(tui): add interactive TUI mode with widget grid (#59)

### DIFF
--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -5,3 +5,4 @@ pub mod file;
 pub mod filter;
 pub mod pager;
 pub mod form;
+pub mod tui;

--- a/src/interactive/tui.rs
+++ b/src/interactive/tui.rs
@@ -1,0 +1,355 @@
+use crossterm::{
+    cursor::{Hide, Show, MoveTo},
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TuiConfig {
+    pub layout: String,
+    pub widgets: Vec<WidgetConfig>,
+    #[serde(default = "default_refresh")]
+    pub refresh_interval: u64,
+}
+
+fn default_refresh() -> u64 {
+    1000
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WidgetConfig {
+    #[serde(rename = "type")]
+    pub widget_type: String,
+    pub content: String,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug)]
+struct Layout {
+    rows: usize,
+    cols: usize,
+}
+
+impl Layout {
+    fn parse(layout_str: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = layout_str.split('x').collect();
+        if parts.len() != 2 {
+            return Err("Invalid layout format (use NxM, e.g., 2x2)".to_string());
+        }
+        let rows = parts[0]
+            .parse::<usize>()
+            .map_err(|_| "Invalid layout format (use NxM, e.g., 2x2)".to_string())?;
+        let cols = parts[1]
+            .parse::<usize>()
+            .map_err(|_| "Invalid layout format (use NxM, e.g., 2x2)".to_string())?;
+        Ok(Layout { rows, cols })
+    }
+
+    fn cell_count(&self) -> usize {
+        self.rows * self.cols
+    }
+}
+
+fn parse_inline_widgets(widgets_str: &str) -> Result<Vec<WidgetConfig>, String> {
+    let mut widgets = Vec::new();
+    for widget_def in widgets_str.split(',') {
+        let widget_def = widget_def.trim();
+        if widget_def.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = widget_def.splitn(2, ':').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid widget definition: '{}' (use type:content)", widget_def));
+        }
+        widgets.push(WidgetConfig {
+            widget_type: parts[0].to_string(),
+            content: parts[1].to_string(),
+            title: None,
+        });
+    }
+    Ok(widgets)
+}
+
+fn render_box_widget(content: &str, width: usize, height: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let inner_width = width.saturating_sub(2);
+    let inner_height = height.saturating_sub(2);
+
+    // Top border
+    lines.push(format!("\x1b[36m{}{}{}\x1b[0m", "┌", "─".repeat(inner_width), "┐"));
+
+    // Content lines
+    let content_lines: Vec<&str> = content.lines().collect();
+    for i in 0..inner_height {
+        let text = content_lines.get(i).copied().unwrap_or("");
+        let display_width = text.chars().count().min(inner_width);
+        let padding = inner_width.saturating_sub(display_width);
+        let truncated: String = text.chars().take(inner_width).collect();
+        lines.push(format!(
+            "\x1b[36m│\x1b[0m{}{}\x1b[36m│\x1b[0m",
+            truncated,
+            " ".repeat(padding)
+        ));
+    }
+
+    // Bottom border
+    lines.push(format!("\x1b[36m{}{}{}\x1b[0m", "└", "─".repeat(inner_width), "┘"));
+
+    lines
+}
+
+fn render_gauge_widget(content: &str, width: usize, height: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let inner_width = width.saturating_sub(4);
+
+    let value: f64 = content.parse().unwrap_or(0.0);
+    let percent = (value / 100.0).clamp(0.0, 1.0);
+    let filled = (inner_width as f64 * percent) as usize;
+    let empty = inner_width.saturating_sub(filled);
+
+    // Title
+    lines.push(format!("\x1b[33m Gauge: {:.0}% \x1b[0m", value));
+
+    // Gauge bar
+    let bar = format!(
+        "  \x1b[42m{}\x1b[0m\x1b[100m{}\x1b[0m",
+        " ".repeat(filled),
+        " ".repeat(empty)
+    );
+    lines.push(bar);
+
+    // Pad remaining height
+    for _ in 2..height {
+        lines.push(" ".repeat(width));
+    }
+
+    lines
+}
+
+fn render_sparkline_widget(content: &str, width: usize, height: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let blocks = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+    // Parse values (support both , and ; as delimiters)
+    let values: Vec<f64> = content
+        .split(|c| c == ',' || c == ';')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect();
+
+    if values.is_empty() {
+        lines.push(" No data ".to_string());
+        for _ in 1..height {
+            lines.push(" ".repeat(width));
+        }
+        return lines;
+    }
+
+    let max_val = values.iter().cloned().fold(f64::MIN, f64::max);
+    let min_val = values.iter().cloned().fold(f64::MAX, f64::min);
+    let range = (max_val - min_val).max(0.001);
+
+    // Title
+    lines.push(format!("\x1b[35m Sparkline \x1b[0m"));
+
+    // Build sparkline
+    let mut spark = String::new();
+    let display_count = values.len().min(width.saturating_sub(2));
+    for val in values.iter().take(display_count) {
+        let normalized = ((val - min_val) / range * 7.0) as usize;
+        let idx = normalized.min(7);
+        spark.push_str(&format!("\x1b[35m{}\x1b[0m", blocks[idx]));
+    }
+    let padding = width.saturating_sub(spark.chars().count() / 10); // Rough estimate due to ANSI codes
+    lines.push(format!(" {}", spark));
+
+    // Pad remaining height
+    for _ in 2..height {
+        lines.push(" ".repeat(width));
+    }
+
+    lines
+}
+
+fn render_log_widget(content: &str, width: usize, height: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let inner_width = width.saturating_sub(2);
+
+    // Title
+    lines.push(format!("\x1b[32m Log \x1b[0m"));
+
+    // Log lines
+    let content_lines: Vec<&str> = content.lines().collect();
+    let max_lines = height.saturating_sub(1);
+    let start = content_lines.len().saturating_sub(max_lines);
+
+    for line in content_lines.iter().skip(start).take(max_lines) {
+        let truncated: String = line.chars().take(inner_width).collect();
+        lines.push(format!(" \x1b[90m>\x1b[0m {}", truncated));
+    }
+
+    // Pad remaining height
+    while lines.len() < height {
+        lines.push(" ".repeat(width));
+    }
+
+    lines
+}
+
+fn render_widget(widget: &WidgetConfig, width: usize, height: usize) -> Vec<String> {
+    match widget.widget_type.as_str() {
+        "box" => render_box_widget(&widget.content, width, height),
+        "gauge" => render_gauge_widget(&widget.content, width, height),
+        "sparkline" => render_sparkline_widget(&widget.content, width, height),
+        "log" => render_log_widget(&widget.content, width, height),
+        _ => {
+            let mut lines = vec![format!(" Unknown: {} ", widget.widget_type)];
+            for _ in 1..height {
+                lines.push(" ".repeat(width));
+            }
+            lines
+        }
+    }
+}
+
+fn render_grid(
+    stdout: &mut io::Stdout,
+    layout: &Layout,
+    widgets: &[WidgetConfig],
+    term_width: u16,
+    term_height: u16,
+) -> io::Result<()> {
+    let cell_width = term_width as usize / layout.cols;
+    let cell_height = (term_height as usize).saturating_sub(2) / layout.rows;
+
+    execute!(stdout, Clear(ClearType::All), MoveTo(0, 0))?;
+
+    // Header
+    writeln!(stdout, "\x1b[7m TUI Mode | {}x{} | Press 'q' to quit \x1b[0m", layout.rows, layout.cols)?;
+
+    for row in 0..layout.rows {
+        let mut row_lines: Vec<Vec<String>> = Vec::new();
+
+        for col in 0..layout.cols {
+            let idx = row * layout.cols + col;
+            let widget = widgets.get(idx);
+            let rendered = if let Some(w) = widget {
+                render_widget(w, cell_width, cell_height)
+            } else {
+                vec![" ".repeat(cell_width); cell_height]
+            };
+            row_lines.push(rendered);
+        }
+
+        // Print row lines
+        for line_idx in 0..cell_height {
+            let mut line = String::new();
+            for col_lines in &row_lines {
+                if let Some(col_line) = col_lines.get(line_idx) {
+                    line.push_str(col_line);
+                } else {
+                    line.push_str(&" ".repeat(cell_width));
+                }
+            }
+            writeln!(stdout, "{}", line)?;
+        }
+    }
+
+    stdout.flush()?;
+    Ok(())
+}
+
+pub fn render(
+    config_path: Option<String>,
+    layout: Option<String>,
+    widgets: Option<String>,
+    refresh: u64,
+) -> Result<(), String> {
+    // Parse configuration
+    let config = if let Some(path) = config_path {
+        let content = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read config file: {}", e))?;
+        serde_json::from_str::<TuiConfig>(&content)
+            .map_err(|e| format!("Failed to parse config file: {}", e))?
+    } else if let (Some(layout_str), Some(widgets_str)) = (layout, widgets) {
+        let parsed_layout = Layout::parse(&layout_str)?;
+        let parsed_widgets = parse_inline_widgets(&widgets_str)?;
+
+        if parsed_widgets.len() != parsed_layout.cell_count() {
+            return Err(format!(
+                "Widget count mismatch: layout {} requires {} widgets, got {}",
+                layout_str,
+                parsed_layout.cell_count(),
+                parsed_widgets.len()
+            ));
+        }
+
+        TuiConfig {
+            layout: layout_str,
+            widgets: parsed_widgets,
+            refresh_interval: refresh,
+        }
+    } else {
+        return Err("Either --config or both --layout and --widgets must be provided".to_string());
+    };
+
+    // Validate layout
+    let layout = Layout::parse(&config.layout)?;
+    if config.widgets.len() != layout.cell_count() {
+        return Err(format!(
+            "Widget count mismatch: layout {} requires {} widgets, got {}",
+            config.layout,
+            layout.cell_count(),
+            config.widgets.len()
+        ));
+    }
+
+    // Enter TUI mode
+    let mut stdout = io::stdout();
+    terminal::enable_raw_mode().map_err(|e| e.to_string())?;
+    execute!(stdout, EnterAlternateScreen, Hide).map_err(|e| e.to_string())?;
+
+    let result = run_tui_loop(&mut stdout, &layout, &config.widgets, config.refresh_interval);
+
+    // Cleanup
+    execute!(stdout, LeaveAlternateScreen, Show).ok();
+    terminal::disable_raw_mode().ok();
+
+    result
+}
+
+fn run_tui_loop(
+    stdout: &mut io::Stdout,
+    layout: &Layout,
+    widgets: &[WidgetConfig],
+    refresh_ms: u64,
+) -> Result<(), String> {
+    let refresh_duration = Duration::from_millis(refresh_ms);
+
+    loop {
+        let (term_width, term_height) = terminal::size().map_err(|e| e.to_string())?;
+        render_grid(stdout, layout, widgets, term_width, term_height)
+            .map_err(|e| e.to_string())?;
+
+        // Poll for events with timeout
+        if event::poll(refresh_duration).map_err(|e| e.to_string())? {
+            if let Event::Key(key_event) = event::read().map_err(|e| e.to_string())? {
+                match key_event.code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        break;
+                    }
+                    KeyCode::Esc => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -544,6 +544,24 @@ enum Commands {
         #[arg(short, long)]
         exit_on_error: bool,
     },
+    /// Interactive TUI mode with widget grid layout
+    ///
+    /// Example: termgfx tui --layout 2x2 --widgets "box:Hello,gauge:75,sparkline:1;2;3,log:Lines"
+    #[command(after_help = "Widget types: box, gauge, sparkline, log\nLayout format: NxM (e.g., 2x2, 3x1)")]
+    Tui {
+        /// JSON config file path
+        #[arg(short, long)]
+        config: Option<String>,
+        /// Layout: NxM (e.g., "2x2", "1x3")
+        #[arg(short, long)]
+        layout: Option<String>,
+        /// Widgets: "type:content,type:content" (e.g., "box:Hello,gauge:75")
+        #[arg(short, long)]
+        widgets: Option<String>,
+        /// Refresh interval in milliseconds
+        #[arg(short, long, default_value = "1000")]
+        refresh: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -917,6 +935,17 @@ fn main() {
                 }
             };
             if let Err(e) = output::watch::render(&command, duration, no_title, differences, exit_on_error) {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Commands::Tui {
+            config,
+            layout,
+            widgets,
+            refresh,
+        } => {
+            if let Err(e) = interactive::tui::render(config, layout, widgets, refresh) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }

--- a/tests/e2e_tui.rs
+++ b/tests/e2e_tui.rs
@@ -1,0 +1,276 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_tui_requires_config_or_layout_and_widgets() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.arg("tui");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Either --config or both --layout and --widgets must be provided"));
+}
+
+#[test]
+fn test_tui_requires_both_layout_and_widgets() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--layout", "2x2"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Either --config or both --layout and --widgets must be provided"));
+}
+
+#[test]
+fn test_tui_inline_widget_count_mismatch() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "2x2",
+        "--widgets", "box:Hello,gauge:75", // Only 2 widgets for 2x2 layout (needs 4)
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_invalid_layout_format() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "invalid",
+        "--widgets", "box:Hello",
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid layout format"));
+}
+
+#[test]
+fn test_tui_invalid_widget_definition() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "invalid", // Missing colon separator
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid widget definition"));
+}
+
+#[test]
+fn test_tui_config_file_not_found() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", "/nonexistent/config.json",
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to read config file"));
+}
+
+#[test]
+fn test_tui_config_file_invalid_json() {
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), "invalid json content").unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_secs(2));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to parse config file"));
+}
+
+#[test]
+fn test_tui_valid_config_file_2x2() {
+    let config = r#"{
+        "layout": "2x2",
+        "widgets": [
+            {"type": "box", "content": "Hello World"},
+            {"type": "gauge", "content": "75"},
+            {"type": "sparkline", "content": "1,2,3,4,5"},
+            {"type": "log", "content": "Log line 1\nLog line 2"}
+        ],
+        "refresh_interval": 1000
+    }"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), config).unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    // The command will timeout since TUI runs in loop, but that's expected
+    // We just want to verify it starts without errors
+    let result = cmd.assert();
+
+    // In CI/non-TTY environments, this might fail immediately
+    // Accept both timeout and specific error messages
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // It should not have parsing errors
+    assert!(!stderr.contains("Failed to parse config file"));
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_valid_inline_1x2() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x2",
+        "--widgets", "box:Hello,gauge:50",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+    assert!(!stderr.contains("Invalid widget definition"));
+}
+
+#[test]
+fn test_tui_valid_inline_3x1() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "3x1",
+        "--widgets", "box:Top,gauge:33,sparkline:1;2;3",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_custom_refresh_interval() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "box:Test",
+        "--refresh", "500",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("error"));
+}
+
+#[test]
+fn test_tui_sparkline_widget() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "1x1",
+        "--widgets", "sparkline:1,2,3,4,5,6,7,8,9",
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Unknown widget type"));
+}
+
+#[test]
+fn test_tui_log_widget_multiline() {
+    let config = r#"{
+        "layout": "1x1",
+        "widgets": [
+            {"type": "log", "content": "Line 1\nLine 2\nLine 3\nLine 4"}
+        ]
+    }"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), config).unwrap();
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--config", temp_file.path().to_str().unwrap(),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("error"));
+}
+
+#[test]
+fn test_tui_large_layout_4x4() {
+    let widgets = vec![
+        "box:1", "box:2", "box:3", "box:4",
+        "gauge:10", "gauge:20", "gauge:30", "gauge:40",
+        "sparkline:1;2", "sparkline:3;4", "sparkline:5;6", "sparkline:7;8",
+        "log:A", "log:B", "log:C", "log:D",
+    ];
+
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&[
+        "tui",
+        "--layout", "4x4",
+        "--widgets", &widgets.join(","),
+    ]);
+    cmd.timeout(Duration::from_millis(500));
+
+    let result = cmd.assert();
+    let output = result.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!stderr.contains("Widget count mismatch"));
+}
+
+#[test]
+fn test_tui_help_message() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Interactive TUI mode"))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--layout"))
+        .stdout(predicate::str::contains("--widgets"))
+        .stdout(predicate::str::contains("--refresh"));
+}
+
+#[test]
+fn test_tui_widget_types_in_help() {
+    let mut cmd = Command::cargo_bin("termgfx").unwrap();
+    cmd.args(&["tui", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("box"))
+        .stdout(predicate::str::contains("gauge"))
+        .stdout(predicate::str::contains("sparkline"))
+        .stdout(predicate::str::contains("log"));
+}


### PR DESCRIPTION
## Summary
Add interactive TUI mode with customizable widget grid layouts.

## Changes
- Add `tui.rs` with full TUI implementation
- Support 4 widget types: box, gauge, sparkline, log
- Grid layouts: NxM (e.g., 2x2, 3x1, 4x4)
- JSON config file support
- Configurable refresh interval
- Keyboard controls: q/Esc/Ctrl+C to quit
- Add 16 E2E tests

## Usage
```bash
# Inline configuration
termgfx tui --layout 2x2 --widgets "box:Hello,gauge:75,sparkline:1;2;3,log:Lines"

# From config file
termgfx tui --config dashboard.json --refresh 500
```

## Widget Types
| Type | Description |
|------|-------------|
| box | Bordered text box |
| gauge | Percentage gauge bar |
| sparkline | Mini line chart |
| log | Scrolling log lines |

## Test Plan
- [x] `cargo test --test e2e_tui` - 16 tests pass
- [x] `termgfx tui --help` shows help

Closes #59